### PR TITLE
Update modal-btns-disabled.js

### DIFF
--- a/src/modal-btns-disabled.js
+++ b/src/modal-btns-disabled.js
@@ -20,9 +20,9 @@ $(document).on("change", function () {
 
       // if not empty - button enabled, else - disabled again
       if (keyEmpty == false && checkEmpty == false) {
-        $("button[type=submit]").removeAttr("disabled");
+        $(".modal.active button[type=submit]").removeAttr("disabled");
       } else {
-        $("button[type=submit]").attr("disabled", "disabled");
+        $(".modal.active button[type=submit]").attr("disabled", "disabled");
       }
     });
 })();


### PR DESCRIPTION
Fixed disabling/enabling for all submit modal buttons

Bug: all submit buttons received/removed property :disabled instead of active modal submit only